### PR TITLE
feat: integrate Nanvix OS target support

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default code owners for all files
+* @ppenna

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,50 @@
+# Project Overview
+
+This project is a fork of the GNU C Compiler (GCC) specifically tailored for the
+Nanvix operating system. It provides a complete toolchain for compiling C, C++
+and Fortran programs for Nanvix.
+
+## Target Architecture Support
+
+This fork introduces the following new target architectures and operating system support:
+- `i686-nanvix` (32-bit x86 for Nanvix)
+- `x86_64-nanvix` (64-bit x86 for Nanvix)
+
+## Key Components
+
+This repository contains the source code of the following development utilities:
+- `gcc` - The GNU C Compiler
+- `g++` - The GNU C++ Compiler
+- `gfortran` - The GNU Fortran Compiler
+
+## Building and Installation
+
+This project uses a custom `z` utility script for streamlined building and installation.
+
+### Quick Start
+
+```bash
+# See all available commands
+./z help
+
+# Complete build process
+./z setup      # Install required system packages
+./z configure  # Configure the build
+./z build      # Compile the source code
+./z install    # Install to default location
+./z release    # Create a release zip file
+```
+
+## Contributing Guidelines
+
+When making changes:
+- **Target Compatibility**: Ensure all changes maintain compatibility with the `i686-nanvix` and `x86_64-nanvix` targets
+- **Testing**: Test changes thoroughly using the build and install process
+- **Code Style**: Follow the established GNU coding standards.
+- **Documentation**: Update relevant documentation and comments
+- **Upstream Compatibility**: Consider impact on future upstream merges from GCC
+
+### Code Style and Standards
+
+This project follows GNU coding standards and conventions.
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: CI/CD Pipeline
+
+#==================================================================================================
+# Trigger Conditions
+#==================================================================================================
+
+on:
+  pull_request:
+    types:
+      - 'opened'
+      - 'synchronize'
+      - 'reopened'
+      - 'ready_for_review'
+    branches:
+      - 'dev'
+
+  push:
+    branches:
+      - 'dev'
+
+# Cancel previous running actions for the same PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/dev' }}
+
+#==================================================================================================
+# Environment Variables
+#==================================================================================================
+
+env:
+  # Directory where GCC will be installed.
+  INSTALL_LOCATION: /opt/nanvix
+
+#==================================================================================================
+# Jobs
+#==================================================================================================
+
+jobs:
+  build:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
+    runs-on: ubuntu-24.04
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Restore sccache cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/sccache
+        key: ${{ runner.os }}-sccache
+        restore-keys: |
+          ${{ runner.os }}-sccache
+
+    - name: Enable compiler caching
+      uses: mozilla-actions/sccache-action@v0.0.9
+
+    - name: Install dependencies
+      run: sudo ./z setup
+
+    - name: Configure GCC (stage 0)
+      run: ./z configure --install-location=${{ env.INSTALL_LOCATION }} --stage=0
+
+    - name: Build GCC (stage 0)
+      run: ./z build
+
+    - name: Configure GCC (stage 1)
+      run: ./z configure --install-location=${{ env.INSTALL_LOCATION }} --stage=1
+
+    - name: Build GCC (stage 1)
+      run: ./z build
+
+    - name: Install GCC
+      run: ./z install

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,27 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: sudo ./z setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,324 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+name: Release Pipeline
+
+#==================================================================================================
+# Trigger Conditions
+#==================================================================================================
+
+on:
+  repository_dispatch:
+    types:
+      - binutils-release
+      - newlib-release
+
+concurrency:
+  group: release-gcc
+  cancel-in-progress: false
+
+#==================================================================================================
+# Environment Variables
+#==================================================================================================
+
+env:
+  # Version of GCC.
+  GCC_VERSION: "13.3.0"
+  # Directory where GCC will be installed.
+  INSTALL_LOCATION: /opt/nanvix
+
+#==================================================================================================
+# Jobs
+#==================================================================================================
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        ref: dev
+        fetch-depth: 0
+
+    - name: Setup Git configuration
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+    - name: Determine build stage
+      id: stage
+      run: |
+        EVENT_TYPE="${{ github.event.action }}"
+        if [ "$EVENT_TYPE" = "binutils-release" ]; then
+          echo "stage=0" >> $GITHUB_OUTPUT
+          echo "stage_label=stage0" >> $GITHUB_OUTPUT
+          echo "dispatch_target=nanvix/newlib" >> $GITHUB_OUTPUT
+          echo "dispatch_event=gcc-stage0-release" >> $GITHUB_OUTPUT
+        elif [ "$EVENT_TYPE" = "newlib-release" ]; then
+          echo "stage=1" >> $GITHUB_OUTPUT
+          echo "stage_label=stage1" >> $GITHUB_OUTPUT
+          echo "dispatch_target=nanvix/toolchain-gcc" >> $GITHUB_OUTPUT
+          echo "dispatch_event=gcc-stage1-release" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Get commit information
+      id: commit_info
+      run: |
+        SHORT_SHA=$(git rev-parse --short HEAD)
+        STAGE_LABEL="${{ steps.stage.outputs.stage_label }}"
+        TAG_NAME="nanvix-v${{ env.GCC_VERSION }}-${SHORT_SHA}-${STAGE_LABEL}"
+        RELEASE_NAME="nanvix-gcc-${{ env.GCC_VERSION }}-${SHORT_SHA}-${STAGE_LABEL}"
+        GCC_BRANCH="nanvix/v${{ env.GCC_VERSION }}"
+        echo "short_sha=${SHORT_SHA}" >> $GITHUB_OUTPUT
+        echo "tag_name=${TAG_NAME}" >> $GITHUB_OUTPUT
+        echo "release_name=${RELEASE_NAME}" >> $GITHUB_OUTPUT
+        echo "gcc_branch=${GCC_BRANCH}" >> $GITHUB_OUTPUT
+
+    - name: Check if release already exists
+      id: check_release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        TAG_NAME="${{ steps.commit_info.outputs.tag_name }}"
+        if git tag -l "${TAG_NAME}" | grep -q .; then
+          echo "tag_exists=true" >> $GITHUB_OUTPUT
+          if gh release view "${TAG_NAME}" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Release ${TAG_NAME} already exists, skipping."
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Tag ${TAG_NAME} exists but GitHub Release does not; continuing to recover from partial previous run."
+          fi
+        else
+          echo "tag_exists=false" >> $GITHUB_OUTPUT
+          echo "exists=false" >> $GITHUB_OUTPUT
+        fi
+
+    #----------------------------------------------------------------------------------------------
+    # Download Dependencies
+    #----------------------------------------------------------------------------------------------
+
+    - name: Download Binutils release
+      if: steps.check_release.outputs.exists == 'false'
+      run: |
+        set -euo pipefail
+        BINUTILS_TAG="${{ github.event.client_payload.binutils_tag }}"
+        echo "Fetching Binutils release: ${BINUTILS_TAG}..."
+        RELEASE_JSON=$(curl -fsS \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          "https://api.github.com/repos/nanvix/binutils/releases/tags/${BINUTILS_TAG}")
+
+        ASSET_URL=$(echo "$RELEASE_JSON" | jq -r '.assets[] | select(.name | test("nanvix-binutils-.*\\.tar\\.bz2$")) | .browser_download_url' | head -n1)
+        if [ -z "$ASSET_URL" ] || [ "$ASSET_URL" = "null" ]; then
+          echo "::error::No binutils tarball asset found for tag ${BINUTILS_TAG}"
+          exit 1
+        fi
+        echo "Downloading Binutils from: $ASSET_URL"
+
+        curl -fsS -L -o /tmp/nanvix-binutils.tar.bz2 "$ASSET_URL"
+        sudo mkdir -p ${{ env.INSTALL_LOCATION }}
+        sudo tar -xjf /tmp/nanvix-binutils.tar.bz2 -C ${{ env.INSTALL_LOCATION }}
+        echo "Binutils extracted to ${{ env.INSTALL_LOCATION }}"
+
+    - name: Download NewLib release
+      if: steps.check_release.outputs.exists == 'false' && steps.stage.outputs.stage == '1'
+      run: |
+        set -euo pipefail
+        NEWLIB_TAG="${{ github.event.client_payload.newlib_tag }}"
+        echo "Fetching NewLib release: ${NEWLIB_TAG}..."
+        RELEASE_JSON=$(curl -fsS \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          "https://api.github.com/repos/nanvix/newlib/releases/tags/${NEWLIB_TAG}")
+
+        ASSET_URL=$(echo "$RELEASE_JSON" | jq -r '.assets[] | select(.name | test("nanvix-newlib-.*\\.tar\\.bz2$")) | .browser_download_url' | head -n1)
+        if [ -z "$ASSET_URL" ] || [ "$ASSET_URL" = "null" ]; then
+          echo "::error::No newlib tarball asset found for tag ${NEWLIB_TAG}"
+          exit 1
+        fi
+        echo "Downloading NewLib from: $ASSET_URL"
+
+        curl -fsS -L -o /tmp/nanvix-newlib.tar.bz2 "$ASSET_URL"
+        sudo tar -xjf /tmp/nanvix-newlib.tar.bz2 -C ${{ env.INSTALL_LOCATION }}
+        echo "NewLib extracted to ${{ env.INSTALL_LOCATION }}"
+
+    #----------------------------------------------------------------------------------------------
+    # Build
+    #----------------------------------------------------------------------------------------------
+
+    - name: Restore sccache cache
+      if: steps.check_release.outputs.exists == 'false'
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/sccache
+        key: ${{ runner.os }}-sccache-release-${{ steps.stage.outputs.stage_label }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-sccache-release-${{ steps.stage.outputs.stage_label }}-
+          ${{ runner.os }}-sccache
+
+    - name: Enable compiler caching
+      if: steps.check_release.outputs.exists == 'false'
+      uses: mozilla-actions/sccache-action@v0.0.9
+
+    - name: Install dependencies
+      if: steps.check_release.outputs.exists == 'false'
+      run: sudo ./z setup
+
+    - name: Configure build
+      if: steps.check_release.outputs.exists == 'false'
+      run: ./z configure --install-location=${{ env.INSTALL_LOCATION }} --sysroot-location=${{ env.INSTALL_LOCATION }} --release-name=${{ steps.commit_info.outputs.release_name }} --stage=${{ steps.stage.outputs.stage }}
+
+    - name: Build
+      if: steps.check_release.outputs.exists == 'false'
+      run: ./z build
+
+    - name: Install
+      if: steps.check_release.outputs.exists == 'false'
+      run: ./z install
+
+    #----------------------------------------------------------------------------------------------
+    # Smoke Test (stage 1 only)
+    #----------------------------------------------------------------------------------------------
+
+    - name: Cross-compile hello-world
+      if: steps.check_release.outputs.exists == 'false' && steps.stage.outputs.stage == '1'
+      run: |
+        export PATH="${{ env.INSTALL_LOCATION }}/bin:$PATH"
+        i686-nanvix-gcc -o /tmp/hello tests/hello.c
+        echo "Cross-compilation succeeded."
+
+    - name: Verify ELF output
+      if: steps.check_release.outputs.exists == 'false' && steps.stage.outputs.stage == '1'
+      run: |
+        export PATH="${{ env.INSTALL_LOCATION }}/bin:$PATH"
+        i686-nanvix-readelf -h /tmp/hello | grep -q ELF
+        echo "ELF verification passed."
+
+    #----------------------------------------------------------------------------------------------
+    # Release Artifacts
+    #----------------------------------------------------------------------------------------------
+
+    - name: Create release archive
+      if: steps.check_release.outputs.exists == 'false'
+      run: ./z release
+
+    #----------------------------------------------------------------------------------------------
+    # Docker Image
+    #----------------------------------------------------------------------------------------------
+
+    - name: Prepare Docker context
+      if: steps.check_release.outputs.exists == 'false'
+      run: |
+        mkdir -p ./docker-install
+        cp -r "${{ env.INSTALL_LOCATION }}/." ./docker-install/
+
+    - name: Set up Docker Buildx
+      if: steps.check_release.outputs.exists == 'false'
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GHCR
+      if: steps.check_release.outputs.exists == 'false'
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Determine Docker tags
+      if: steps.check_release.outputs.exists == 'false'
+      id: docker_tags
+      run: |
+        SHORT_SHA="${{ steps.commit_info.outputs.short_sha }}"
+        STAGE="${{ steps.stage.outputs.stage }}"
+        if [ "$STAGE" = "0" ]; then
+          echo "tags=ghcr.io/nanvix/gcc:stage0-latest,ghcr.io/nanvix/gcc:stage0-${SHORT_SHA}" >> $GITHUB_OUTPUT
+        else
+          echo "tags=ghcr.io/nanvix/gcc:latest,ghcr.io/nanvix/gcc:${SHORT_SHA}" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Build and push Docker image
+      if: steps.check_release.outputs.exists == 'false'
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        push: true
+        tags: ${{ steps.docker_tags.outputs.tags }}
+
+    - name: Make package public
+      if: steps.check_release.outputs.exists == 'false'
+      run: |
+        curl -fsS -X PATCH \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "https://api.github.com/orgs/${{ github.repository_owner }}/packages/container/gcc" \
+          -d '{"visibility":"public"}' || true
+
+    #----------------------------------------------------------------------------------------------
+    # Git Operations
+    #----------------------------------------------------------------------------------------------
+
+    - name: Fast-forward release branch
+      if: steps.check_release.outputs.exists == 'false'
+      run: |
+        git fetch origin
+        git checkout -B ${{ steps.commit_info.outputs.gcc_branch }} origin/dev
+        git push origin ${{ steps.commit_info.outputs.gcc_branch }}
+
+    - name: Create release tag
+      if: steps.check_release.outputs.exists == 'false' && steps.check_release.outputs.tag_exists == 'false'
+      run: |
+        git tag ${{ steps.commit_info.outputs.tag_name }}
+        git push origin ${{ steps.commit_info.outputs.tag_name }}
+
+    - name: Create GitHub Release
+      if: steps.check_release.outputs.exists == 'false'
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: ${{ steps.commit_info.outputs.tag_name }}
+        name: "${{ steps.commit_info.outputs.tag_name }}"
+        body: |
+          Automated release of Nanvix GCC ${{ env.GCC_VERSION }} (${{ steps.stage.outputs.stage_label }})
+
+          Built from commit: ${{ steps.commit_info.outputs.short_sha }}
+          Triggered by: ${{ github.event.action }}
+
+          This release contains the GCC toolchain configured for the Nanvix operating system target (i686-nanvix).
+
+          **Artifacts:**
+          - Tarball: `${{ steps.commit_info.outputs.release_name }}.tar.bz2`
+          - Docker: `${{ steps.docker_tags.outputs.tags }}`
+        files: |
+          ${{ steps.commit_info.outputs.release_name }}.tar.bz2
+        draft: false
+        prerelease: false
+
+    #----------------------------------------------------------------------------------------------
+    # Cross-Repository Dispatch
+    #----------------------------------------------------------------------------------------------
+
+    - name: Dispatch to next repository
+      if: steps.check_release.outputs.exists == 'false'
+      run: |
+        curl -fsS -X POST \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${{ secrets.DISPATCH_TOKEN }}" \
+          https://api.github.com/repos/${{ steps.stage.outputs.dispatch_target }}/dispatches \
+          -d '{
+            "event_type": "${{ steps.stage.outputs.dispatch_event }}",
+            "client_payload": {
+              "gcc_version": "${{ env.GCC_VERSION }}",
+              "gcc_tag": "${{ steps.commit_info.outputs.tag_name }}",
+              "gcc_sha": "${{ steps.commit_info.outputs.short_sha }}",
+              "gcc_stage": "${{ steps.stage.outputs.stage }}",
+              "binutils_tag": "${{ github.event.client_payload.binutils_tag }}",
+              "newlib_tag": "${{ github.event.client_payload.newlib_tag }}"
+            }
+          }'

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,9 @@ stamp-*
 /mpc*
 /gmp*
 /isl*
+
+# Build artifacts.
+/build/
+
+.z.config
+nanvix-gcc.tar.bz2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Copyright(c) The Maintainers of Nanvix.
+# Licensed under the MIT License.
+
+# =============================================================================
+# nanvix/gcc
+#
+# Lightweight runtime image with Nanvix GCC cross-compiler for i686-nanvix.
+#
+# This image is built by the release workflow, which copies pre-built artifacts
+# into docker-install/ before running `docker build`.
+#
+# Build (from release workflow):
+#   docker build -t ghcr.io/nanvix/gcc:latest .
+#
+# Verify:
+#   docker run --rm ghcr.io/nanvix/gcc:latest i686-nanvix-gcc --version
+# =============================================================================
+
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install minimal runtime dependencies.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        make \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY docker-install/ /opt/nanvix/
+
+ENV PATH="/opt/nanvix/bin:${PATH}"
+
+# Smoke test.
+RUN i686-nanvix-gcc --version && \
+    i686-nanvix-as --version && \
+    i686-nanvix-ld --version
+
+LABEL org.opencontainers.image.source="https://github.com/nanvix/gcc" \
+      org.opencontainers.image.description="Nanvix GCC cross-compilation toolchain (GCC, G++, Gfortran) for i686-nanvix"

--- a/config.sub
+++ b/config.sub
@@ -1749,7 +1749,7 @@ case $os in
 	     | onefs* | tirtos* | phoenix* | fuchsia* | redox* | bme* \
 	     | midnightbsd* | amdhsa* | unleashed* | emscripten* | wasi* \
 	     | nsk* | powerunix* | genode* | zvmoe* | qnx* | emx* | zephyr* \
-	     | fiwix* )
+	     | fiwix* | nanvix* )
 		;;
 	# This one is extra strict with allowed versions
 	sco3.2v2 | sco3.2v[4-9]* | sco5v6*)

--- a/fixincludes/mkfixinc.sh
+++ b/fixincludes/mkfixinc.sh
@@ -11,6 +11,7 @@ target=fixinc.sh
 
 # Check for special fix rules for particular targets
 case $machine in
+    *-nanvix* | \
     i?86-*-cygwin* | \
     i?86-*-mingw32* | \
     x86_64-*-mingw32* | \

--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -927,6 +927,13 @@ case ${target} in
       ;;
   esac
   ;;
+*-*-nanvix*)
+  extra_options="$extra_options gnu-user.opt"
+  gas=yes
+  gnu_ld=yes
+  default_use_cxa_atexit=yes
+  use_gcc_stdint=provide
+  ;;
 *-*-netbsd*)
   tm_p_file="${tm_p_file} netbsd-protos.h"
   tmake_file="t-netbsd t-slibgcc"
@@ -1877,6 +1884,12 @@ i[34567]86-*-rdos*)
 x86_64-*-rdos*)
     tm_file="${tm_file} i386/unix.h i386/att.h elfos.h newlib-stdint.h i386/i386elf.h i386/x86-64.h i386/rdos.h i386/rdos64.h"
     tmake_file="i386/t-i386elf t-svr4"
+    ;;
+i[34567]86-*-nanvix*)
+    tm_file="${tm_file} i386/unix.h i386/att.h elfos.h newlib-stdint.h i386/i386elf.h nanvix.h"
+    ;;
+x86_64-*-nanvix*)
+    tm_file="${tm_file} i386/unix.h i386/att.h elfos.h newlib-stdint.h i386/i386elf.h i386/x86-64.h nanvix.h"
     ;;
 i[34567]86-*-dragonfly*)
 	tm_file="${tm_file} i386/unix.h i386/att.h elfos.h dragonfly.h dragonfly-stdint.h i386/dragonfly.h"

--- a/gcc/config/nanvix.h
+++ b/gcc/config/nanvix.h
@@ -1,0 +1,31 @@
+/* Useful if you wish to make target-specific GCC changes. */
+#undef TARGET_NANVIX
+#define TARGET_NANVIX 1
+
+/* Default arguments you want when running your
+   i686-nanvix-gcc/x86_64-nanvix-gcc toolchain */
+#undef LIB_SPEC
+#define LIB_SPEC "%{!shared:-lc}" /* link against C standard library */
+
+/* Files that are linked before user code.
+   The %s tells GCC to look for these files in the library directory. */
+#undef STARTFILE_SPEC
+#define STARTFILE_SPEC "%{!shared:crt0.o%s} %{!shared:crti.o%s} %{!shared:crtbegin.o%s}"
+
+/* Files that are linked after user code. */
+#undef ENDFILE_SPEC
+#define ENDFILE_SPEC "%{!shared:crtend.o%s} %{!shared:crtn.o%s}"
+
+#undef LINK_SPEC
+#define LINK_SPEC "%{shared:-shared} %{static:-static} %{!shared: %{!static: %{rdynamic:-export-dynamic}}}"
+
+/* Additional predefined macros. */
+#undef TARGET_OS_CPP_BUILTINS
+#define TARGET_OS_CPP_BUILTINS()      \
+  do {                                \
+    builtin_define ("__nanvix__");      \
+    builtin_define ("__unix__");      \
+    builtin_assert ("system=nanvix");   \
+    builtin_assert ("system=unix");   \
+    builtin_assert ("system=posix");   \
+  } while(0);

--- a/libgcc/config.host
+++ b/libgcc/config.host
@@ -779,6 +779,14 @@ i[34567]86-pc-msdosdjgpp*)
 	;;
 i[34567]86-*-lynxos*)
 	;;
+i[34567]86-*-nanvix*)
+	extra_parts="$extra_parts crti.o crtbegin.o crtend.o crtn.o"
+	tmake_file="$tmake_file i386/t-crtstuff t-crtstuff-pic t-libgcc-pic"
+	;;
+x86_64-*-nanvix*)
+	extra_parts="$extra_parts crti.o crtbegin.o crtend.o crtn.o"
+	tmake_file="$tmake_file i386/t-crtstuff t-crtstuff-pic t-libgcc-pic"
+	;;
 i[34567]86-*-nto-qnx*)
 	tmake_file="$tmake_file i386/t-nto t-libgcc-pic"
 	extra_parts=crtbegin.o

--- a/libstdc++-v3/config/os/nanvix/ctype_base.h
+++ b/libstdc++-v3/config/os/nanvix/ctype_base.h
@@ -1,0 +1,61 @@
+// Locale support -*- C++ -*-
+
+// Copyright (C) 2000-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// Under Section 7 of GPL version 3, you are granted additional
+// permissions described in the GCC Runtime Library Exception, version
+// 3.1, as published by the Free Software Foundation.
+
+// You should have received a copy of the GNU General Public License and
+// a copy of the GCC Runtime Library Exception along with this program;
+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+//
+// ISO C++ 14882: 22.1  Locales
+//
+
+// Information as gleaned from /usr/include/ctype.h
+
+namespace std _GLIBCXX_VISIBILITY(default)
+{
+_GLIBCXX_BEGIN_NAMESPACE_VERSION
+
+  /// @brief  Base class for ctype.
+  struct ctype_base
+  {
+    // Non-standard typedefs.
+    typedef const int* 		__to_type;
+
+    // NB: Offsets into ctype<char>::_M_table force a particular size
+    // on the mask type. Because of this, we don't use an enum.
+    typedef char 		mask;
+    static const mask upper    	= _U;
+    static const mask lower 	= _L;
+    static const mask alpha 	= _U | _L;
+    static const mask digit 	= _N;
+    static const mask xdigit 	= _X | _N;
+    static const mask space 	= _S;
+    static const mask print 	= _P | _U | _L | _N | _B;
+    static const mask graph 	= _P | _U | _L | _N;
+    static const mask cntrl 	= _C;
+    static const mask punct 	= _P;
+    static const mask alnum 	= _U | _L | _N;
+#if __cplusplus >= 201103L
+    static const mask blank 	= space;
+#endif
+  };
+
+_GLIBCXX_END_NAMESPACE_VERSION
+} // namespace

--- a/libstdc++-v3/config/os/nanvix/ctype_configure_char.cc
+++ b/libstdc++-v3/config/os/nanvix/ctype_configure_char.cc
@@ -1,0 +1,105 @@
+// Locale support -*- C++ -*-
+
+// Copyright (C) 2011-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// Under Section 7 of GPL version 3, you are granted additional
+// permissions described in the GCC Runtime Library Exception, version
+// 3.1, as published by the Free Software Foundation.
+
+// You should have received a copy of the GNU General Public License and
+// a copy of the GCC Runtime Library Exception along with this program;
+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+/** @file ctype_configure_char.cc */
+
+//
+// ISO C++ 14882: 22.1  Locales
+//
+
+#include <locale>
+#include <cstdlib>
+#include <cstring>
+
+namespace std _GLIBCXX_VISIBILITY(default)
+{
+_GLIBCXX_BEGIN_NAMESPACE_VERSION
+
+// Information as gleaned from /usr/include/ctype.h
+
+  const ctype_base::mask*
+  ctype<char>::classic_table() throw()
+  { return _ctype_ + 1; }
+
+  ctype<char>::ctype(__c_locale, const mask* __table, bool __del,
+		     size_t __refs)
+  : facet(__refs), _M_del(__table != 0 && __del),
+  _M_toupper(NULL), _M_tolower(NULL),
+  _M_table(__table ? __table : classic_table())
+  {
+    memset(_M_widen, 0, sizeof(_M_widen));
+    _M_widen_ok = 0;
+    memset(_M_narrow, 0, sizeof(_M_narrow));
+    _M_narrow_ok = 0;
+  }
+
+  ctype<char>::ctype(const mask* __table, bool __del, size_t __refs)
+  : facet(__refs), _M_del(__table != 0 && __del),
+  _M_toupper(NULL), _M_tolower(NULL),
+  _M_table(__table ? __table : classic_table())
+  {
+    memset(_M_widen, 0, sizeof(_M_widen));
+    _M_widen_ok = 0;
+    memset(_M_narrow, 0, sizeof(_M_narrow));
+    _M_narrow_ok = 0;
+  }
+
+  char
+  ctype<char>::do_toupper(char __c) const
+  {
+    int __x = __c;
+    return (this->is(ctype_base::lower, __c) ? (__x - 'a' + 'A') : __x);
+  }
+
+  const char*
+  ctype<char>::do_toupper(char* __low, const char* __high) const
+  {
+    while (__low < __high)
+      {
+	*__low = this->do_toupper(*__low);
+	++__low;
+      }
+    return __high;
+  }
+
+  char
+  ctype<char>::do_tolower(char __c) const
+  {
+    int __x = __c;
+    return (this->is(ctype_base::upper, __c) ? (__x - 'A' + 'a') : __x);
+  }
+
+  const char*
+  ctype<char>::do_tolower(char* __low, const char* __high) const
+  {
+    while (__low < __high)
+      {
+	*__low = this->do_tolower(*__low);
+	++__low;
+      }
+    return __high;
+  }
+
+_GLIBCXX_END_NAMESPACE_VERSION
+} // namespace

--- a/libstdc++-v3/config/os/nanvix/ctype_inline.h
+++ b/libstdc++-v3/config/os/nanvix/ctype_inline.h
@@ -1,0 +1,74 @@
+// Locale support -*- C++ -*-
+
+// Copyright (C) 2000-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// Under Section 7 of GPL version 3, you are granted additional
+// permissions described in the GCC Runtime Library Exception, version
+// 3.1, as published by the Free Software Foundation.
+
+// You should have received a copy of the GNU General Public License and
+// a copy of the GCC Runtime Library Exception along with this program;
+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+/** @file bits/ctype_inline.h
+ *  This is an internal header file, included by other library headers.
+ *  Do not attempt to use it directly. @headername{locale}
+ */
+
+//
+// ISO C++ 14882: 22.1  Locales
+//
+
+// ctype bits to be inlined go here. Non-inlinable (ie virtual do_*)
+// functions go in ctype.cc
+
+namespace std _GLIBCXX_VISIBILITY(default)
+{
+_GLIBCXX_BEGIN_NAMESPACE_VERSION
+
+  bool
+  ctype<char>::
+  is(mask __m, char __c) const
+  { return _M_table[static_cast<unsigned char>(__c)] & __m; }
+
+  const char*
+  ctype<char>::
+  is(const char* __low, const char* __high, mask* __vec) const
+  {
+    while (__low < __high)
+      *__vec++ = _M_table[static_cast<unsigned char>(*__low++)];
+    return __high;
+  }
+
+  const char*
+  ctype<char>::
+  scan_is(mask __m, const char* __low, const char* __high) const
+  {
+    while (__low < __high && !this->is(__m, *__low))
+      ++__low;
+    return __low;
+  }
+
+  const char*
+  ctype<char>::
+  scan_not(mask __m, const char* __low, const char* __high) const
+  {
+    while (__low < __high && this->is(__m, *__low) != 0)
+      ++__low;
+    return __low;
+  }
+
+_GLIBCXX_END_NAMESPACE_VERSION
+} // namespace

--- a/libstdc++-v3/config/os/nanvix/os_defines.h
+++ b/libstdc++-v3/config/os/nanvix/os_defines.h
@@ -1,0 +1,61 @@
+// Specific definitions for newlib  -*- C++ -*-
+
+// Copyright (C) 2000-2022 Free Software Foundation, Inc.
+//
+// This file is part of the GNU ISO C++ Library.  This library is free
+// software; you can redistribute it and/or modify it under the
+// terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 3, or (at your option)
+// any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// Under Section 7 of GPL version 3, you are granted additional
+// permissions described in the GCC Runtime Library Exception, version
+// 3.1, as published by the Free Software Foundation.
+
+// You should have received a copy of the GNU General Public License and
+// a copy of the GCC Runtime Library Exception along with this program;
+// see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+// <http://www.gnu.org/licenses/>.
+
+/** @file bits/os_defines.h
+ *  This is an internal header file, included by other library headers.
+ *  Do not attempt to use it directly. @headername{iosfwd}
+ */
+
+#ifndef _GLIBCXX_OS_DEFINES
+#define _GLIBCXX_OS_DEFINES 1
+
+// System-specific #define, typedefs, corrections, etc, go here.  This
+// file will come before all others.
+
+#ifdef __CYGWIN__
+#define _GLIBCXX_GTHREAD_USE_WEAK 0
+
+#if defined (_GLIBCXX_DLL)
+#define _GLIBCXX_PSEUDO_VISIBILITY_default __attribute__ ((__dllimport__))
+#else
+#define _GLIBCXX_PSEUDO_VISIBILITY_default
+#endif
+#define _GLIBCXX_PSEUDO_VISIBILITY_hidden
+
+#define _GLIBCXX_PSEUDO_VISIBILITY(V) _GLIBCXX_PSEUDO_VISIBILITY_ ## V
+
+// See libstdc++/20806.
+#define _GLIBCXX_HAVE_DOS_BASED_FILESYSTEM 1
+
+// Enable use of GetModuleHandleEx (requires Windows XP/2003) in
+// __cxa_thread_atexit to prevent modules from being unloaded before
+// their dtors are called
+#define _GLIBCXX_THREAD_ATEXIT_WIN32 1
+
+// See libstdc++/69506
+#define _GLIBCXX_USE_WEAK_REF 0
+
+#endif
+
+#endif

--- a/libstdc++-v3/configure.host
+++ b/libstdc++-v3/configure.host
@@ -283,6 +283,9 @@ case "${host_os}" in
     esac
     OPT_LDFLAGS="${OPT_LDFLAGS} \$(lt_host_flags)"
     ;;
+  nanvix*)
+    os_include_dir="os/nanvix"
+    ;;
   netbsd*)
     os_include_dir="os/bsd/netbsd"
     ;;

--- a/libstdc++-v3/crossconfig.m4
+++ b/libstdc++-v3/crossconfig.m4
@@ -219,6 +219,12 @@ case "${host}" in
     AC_CHECK_FUNCS(timespec_get)
     AC_CHECK_FUNCS(sockatmark)
     ;;
+  *-nanvix*)
+    GLIBCXX_CHECK_COMPILER_FEATURES
+    GLIBCXX_CHECK_LINKER_FEATURES
+    GLIBCXX_CHECK_MATH_SUPPORT
+    GLIBCXX_CHECK_STDLIB_SUPPORT
+    ;;
   *-qnx6.1* | *-qnx6.2*)
     SECTION_FLAGS='-ffunction-sections -fdata-sections'
     AC_SUBST(SECTION_FLAGS) 

--- a/tests/hello.c
+++ b/tests/hello.c
@@ -1,0 +1,10 @@
+// Copyright(c) The Maintainers of Nanvix.
+// Licensed under the MIT License.
+
+// Minimal hello-world smoke test for the GCC cross-compilation toolchain.
+// This file must compile and link successfully with:
+//   i686-nanvix-gcc -o hello hello.c
+
+int main(void) {
+    return 0;
+}

--- a/z
+++ b/z
@@ -1,0 +1,285 @@
+#!/bin/bash
+
+#
+# Utility for building development tools for Nanvix.
+#
+# Run './z help' for more information on how to use this utility.
+#
+# Relevant Environment Variables
+#
+#   - Z_TARGET: Target architecture.
+#   - Z_STAGE: Build stage.
+#   - Z_INSTALL_LOCATION: Installation directory.
+#   - Z_SYSROOT_LOCATION: Sysroot directory.
+#   - Z_RELEASE_NAME: Release name.
+#
+# shellcheck disable=SC2329
+# shellcheck disable=SC2317
+# shellcheck disable=SC2034
+
+#==================================================================================================
+
+# Fast fail on errors, unset variables, and pipe failures.
+set -euo pipefail
+
+#==================================================================================================
+# Import Utils Script
+#==================================================================================================
+
+UTILS_SCRIPT_VERSION="c24dedaf76a4833b388597805e2c0625cef0c453"
+UTILS_SCRIPT_URL="https://raw.githubusercontent.com/nanvix/scripts/${UTILS_SCRIPT_VERSION}/utils.sh"
+UTILS_SCRIPT_SHA256="c2d0402cc407963d83afd32d9ffe49c19e25f386172e89bf09812393230388bb"
+
+utils_script_dir=$(mktemp -d)
+trap 'rm -rf "$utils_script_dir"' EXIT
+utils_script="${utils_script_dir}/utils-${UTILS_SCRIPT_VERSION}.sh"
+
+# Download only if the file doesn't exist or is empty
+if [[ ! -s "$utils_script" ]]; then
+
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL "$UTILS_SCRIPT_URL" -o "$utils_script" || {
+            echo "Failed to download utils.sh"
+            rm -f "$utils_script"
+            exit 1
+        }
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO "$utils_script" "$UTILS_SCRIPT_URL" || {
+            echo "Failed to download utils.sh"
+            rm -f "$utils_script"
+            exit 1
+        }
+    else
+        echo "curl or wget required"
+        exit 1
+    fi
+
+    # Verify integrity before sourcing
+    echo "${UTILS_SCRIPT_SHA256}  ${utils_script}" | sha256sum -c --quiet || {
+        echo "Checksum verification failed for utils.sh"
+        rm -f "$utils_script"
+        exit 1
+    }
+fi
+
+# Source the downloaded script
+# shellcheck disable=SC1090
+source "${utils_script}"
+
+#==================================================================================================
+# Z Constants
+#==================================================================================================
+
+# Project name.
+readonly Z_PROJECT_NAME="GCC"
+# Directory used when building, empty if not required.
+readonly Z_PROJECT_BUILD_DIR="build"
+
+# Required Build Tools (tool_name => minimum_version)
+readonly -A Z_PROJECT_REQUIRED_TOOLS=(
+    ["gcc"]="13.3.0"
+    ["make"]="4.3.0"
+    ["bzip2"]="1.0.8"
+    ["tar"]="1.34.0"
+    ["wget"]="1.21.4"
+)
+
+# Required System Packages for Setup
+readonly Z_PROJECT_REQUIRED_PACKAGES=("build-essential" "wget" "bzip2" "tar")
+
+#==================================================================================================
+# Project-Specific Constants
+#==================================================================================================
+
+# Build Targets
+readonly BUILD_TARGETS_STAGE_0=("all-gcc" "all-target-libgcc")
+readonly BUILD_TARGETS_STAGE_1=("all-gcc" "all-target-libgcc" "all-target-libstdc++-v3")
+
+# Install Targets
+readonly INSTALL_TARGETS_STAGE_0=("install-gcc" "install-target-libgcc")
+readonly INSTALL_TARGETS_STAGE_1=("install-gcc" "install-target-libgcc" "install-target-libstdc++-v3")
+
+# Binutils.
+readonly BINUTILS_VERSION="2.40"
+readonly BINUTILS_SHORT_COMMIT_HASH="cce4ffcd98"
+readonly BINUTILS_URL="https://github.com/nanvix/binutils/releases/download/nanvix-v${BINUTILS_VERSION}-${BINUTILS_SHORT_COMMIT_HASH}/nanvix-binutils-${BINUTILS_VERSION}-${BINUTILS_SHORT_COMMIT_HASH}.tar.bz2"
+readonly BINUTILS_SHA256_CHECKSUM="sha256:904980cde09ff38eb73f3f275c366bad8178e36ae7f88775eba988d41e8407b8"
+
+# NewLib
+readonly NEWLIB_VERSION="4.4.0"
+readonly NEWLIB_SHORT_COMMIT_HASH="e12d84a67"
+readonly NEWLIB_URL="https://github.com/nanvix/newlib/releases/download/nanvix-v${NEWLIB_VERSION}-${NEWLIB_SHORT_COMMIT_HASH}/nanvix-newlib-${NEWLIB_VERSION}-${NEWLIB_SHORT_COMMIT_HASH}.tar.bz2"
+readonly NEWLIB_SHA256_CHECKSUM="sha256:94e7771fd4e9cc495dac846d468d4214617a510cda1e8c964e4a19bf2a1c2694"
+
+#==================================================================================================
+# Project-Specific Functions
+#==================================================================================================
+
+#
+# Description
+#
+#   Executes project-specific steps for downloading dependencies.
+#
+# Return Value
+#
+#   - On success, this function returns zero.
+#   - On failure, this function returns non-zero.
+#
+download_steps() {
+
+    # Download pre-requisites.
+    ./contrib/download_prerequisites
+
+    # Download and extract Binutils if sysroot location is not set.
+    if [[ -z "${Z_SYSROOT_LOCATION:-}" ]]; then
+        local sysroot_location="${Z_INSTALL_LOCATION}"
+
+        local binutils_tar_bz2_file
+        binutils_tar_bz2_file=$(download "$BINUTILS_URL" "$BINUTILS_SHA256_CHECKSUM") || {
+            print_error "Failed to download Binutils."
+            return 1
+        }
+        extract_tar_bz2 "$binutils_tar_bz2_file" "$sysroot_location" || {
+            print_error "Failed to extract Binutils."
+            return 1
+        }
+
+        # Download and extract NewLib if configuring stage 1.
+        if [[ "${Z_STAGE}" == "1" ]]; then
+            local newlib_tar_bz2_file
+            newlib_tar_bz2_file=$(download "$NEWLIB_URL" "$NEWLIB_SHA256_CHECKSUM") || {
+                print_error "Failed to download NewLib."
+                return 1
+            }
+            extract_tar_bz2 "$newlib_tar_bz2_file" "${sysroot_location}" || {
+                print_error "Failed to extract NewLib."
+                return 1
+            }
+        fi
+    fi
+
+    return 0
+}
+
+#
+# Description
+#
+#   Executes project-specific steps for configuring a build.
+#
+# Return Value
+#
+#   - On success, this function returns zero.
+#   - On failure, this function returns non-zero.
+#
+# Usage Example
+#
+#   configure_steps "i686-nanvix" "/usr/local"
+#
+configure_steps() {
+    local sysroot_location="${Z_SYSROOT_LOCATION:-${Z_INSTALL_LOCATION}}"
+
+    # Enable compilation caching if possible.
+    enable_compilation_caching || {
+        print_warning "Compilation caching disabled."
+    }
+
+    ../configure \
+        --target="${Z_TARGET}" \
+        --prefix="${Z_INSTALL_LOCATION}" \
+        --with-sysroot="${sysroot_location}" \
+        --disable-multilib \
+        --disable-nls \
+        --enable-languages=c,c++,fortran  \
+        --disable-libquadmath \
+        --disable-libquadmath-support \
+        --with-newlib || {
+        print_error "Configuration failed."
+        return 1
+    }
+
+    return 0
+}
+
+#
+# Description
+#
+#   Project-specific steps for building the project.
+#
+# Parameters
+#
+#   - $1: Number of parallel build jobs.
+#
+# Usage Example
+#
+#   build_steps 4 "all" "check"
+#
+build_steps() {
+    local parallel_build_option=$1
+
+    # Collect build targets.
+    local build_targets=()
+    if [[ "${Z_STAGE}" == "0" ]]; then
+        build_targets=("${BUILD_TARGETS_STAGE_0[@]}")
+    elif [[ "${Z_STAGE}" == "1" ]]; then
+        build_targets=("${BUILD_TARGETS_STAGE_1[@]}")
+    else
+        print_error "Invalid stage '$Z_STAGE'."
+        return 1
+    fi
+
+    # Enable compilation caching if possible.
+    enable_compilation_caching || {
+        print_warning "Compilation caching disabled."
+    }
+
+    make -j "${parallel_build_option}" "${build_targets[@]}" || {
+        print_error "Build failed for targets: '${build_targets[*]}'."
+        return 1
+    }
+
+    return 0
+}
+
+#
+# Description
+#
+#   Project-specific steps for installing the project.
+#
+# Return Value
+#
+#   - On success, this function returns zero.
+#   - On failure, this function returns non-zero.
+#
+# Usage Example
+#
+#   install_steps "install" "/usr/local"
+#
+install_steps() {
+    local install_targets=()
+    if [[ "${Z_STAGE}" == "0" ]]; then
+        install_targets=("${INSTALL_TARGETS_STAGE_0[@]}")
+    elif [[ "${Z_STAGE}" == "1" ]]; then
+        install_targets=("${INSTALL_TARGETS_STAGE_1[@]}")
+    else
+        print_error "Invalid stage '$Z_STAGE'. Use '0' or '1'."
+        return 1
+    fi
+
+    make "${install_targets[@]}" || {
+        print_error "Installation failed."
+        return 1
+    }
+
+    return 0
+}
+
+#==================================================================================================
+# Main Script
+#==================================================================================================
+
+# Run main function with all arguments
+zmain "$@" || {
+    exit 1
+}
+
+exit 0


### PR DESCRIPTION
## Summary

Add Nanvix OS target (`i686-nanvix`, `x86_64-nanvix`) support to GCC 13.3.0, including libstdc++ and libgfortran.

## Target Support
- `config.sub`: OS recognition for `nanvix*`
- `gcc/config.gcc`: generic `*-*-nanvix*` defaults + i386/x86_64 entries
- `gcc/config/nanvix.h`: target header (`__nanvix__`, `__unix__`, LIB/STARTFILE/ENDFILE/LINK specs)
- `libgcc/config.host`: CRT objects for nanvix targets
- `libstdc++-v3/configure.host`: OS include dir for `nanvix*`
- `libstdc++-v3/crossconfig.m4`: cross-compilation checks
- `libstdc++-v3/config/os/nanvix/`: 4 OS support files
- `fixincludes/mkfixinc.sh`: added `*-nanvix*` to no-op list
- `libgfortran`: compatibility fixes

## Build Infrastructure
- `z` build script, CI release workflow (`GCC_VERSION="13.3.0"`)
- Dockerfile, `.github/`, tests/

## Testing
- Stage 0 + Stage 1 build successfully
- 14 posix-tests suites compiled (including C++); 7/9 pass on nanvixd
