### PR TITLE
libstdc++: emit HAVE_*L long-double math defines on i386/x86_64 newlib targets

### DIFF
--- a/libstdc++-v3/configure
+++ b/libstdc++-v3/configure
@@ -29369,6 +29369,74 @@ else
 
         ;;
     esac
+
+    # Newlib provides 80-bit long-double math on i386/x86_64.  Define
+    # the HAVE_*L macros so that the long-double stubs in
+    # src/c++98/math_stubs_long_double.cc are suppressed and do not
+    # conflict with newlib libm.a's strong definitions at static link
+    # time.
+    #
+    # Previously this set of AC_DEFINE calls lived in a block guarded by
+    #   if test x"long_double_math_on_this_cpu" = x"yes"; then ...
+    # which compares the literal string "long_double_math_on_this_cpu"
+    # against "yes" (the leading `$` was omitted) and is therefore
+    # permanently false.  The block carried a "for the time being, punt"
+    # comment since libstdc++'s introduction; promote it to a real CPU
+    # check now, scoped to newlib targets so non-newlib cross builds
+    # (which reach this file via GLIBCXX_CROSSCONFIG in the elif below)
+    # are unaffected.
+    case "${target_cpu}" in
+      i[3456789]86 | x86_64)
+        $as_echo "#define HAVE_ACOSL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_ASINL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_ATAN2L 1" >>confdefs.h
+
+        $as_echo "#define HAVE_ATANL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_CEILL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_COSL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_COSHL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_EXPL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_FABSL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_FLOORL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_FMODL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_FREXPL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_HYPOTL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_LDEXPL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_LOG10L 1" >>confdefs.h
+
+        $as_echo "#define HAVE_LOGL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_MODFL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_POWL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_SINCOSL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_SINL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_SINHL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_SQRTL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_TANL 1" >>confdefs.h
+
+        $as_echo "#define HAVE_TANHL 1" >>confdefs.h
+
+        ;;
+    esac
   elif test "x$with_headers" != "xno"; then
 
 # Base decisions on target environment.
@@ -68283,57 +68351,6 @@ esac
 
   fi
 
-  # At some point, we should differentiate between architectures
-  # like x86, which have long double versions, and alpha/powerpc/etc.,
-  # which don't. For the time being, punt.
-  if test x"long_double_math_on_this_cpu" = x"yes"; then
-    $as_echo "#define HAVE_ACOSL 1" >>confdefs.h
-
-    $as_echo "#define HAVE_ASINL 1" >>confdefs.h
-
-    $as_echo "#define HAVE_ATAN2L 1" >>confdefs.h
-
-    $as_echo "#define HAVE_ATANL 1" >>confdefs.h
-
-    $as_echo "#define HAVE_CEILL 1" >>confdefs.h
-
-    $as_echo "#define HAVE_COSL 1" >>confdefs.h
-
-    $as_echo "#define HAVE_COSHL 1" >>confdefs.h
-
-    $as_echo "#define HAVE_EXPL 1" >>confdefs.h
-
-    $as_echo "#define HAVE_FABSL 1" >>confdefs.h
-
-    $as_echo "#define HAVE_FLOORL 1" >>confdefs.h
-
-    $as_echo "#define HAVE_FMODL 1" >>confdefs.h
-
-    $as_echo "#define HAVE_FREXPL 1" >>confdefs.h
-
-    $as_echo "#define HAVE_LDEXPL 1" >>confdefs.h
-
-    $as_echo "#define HAVE_LOG10L 1" >>confdefs.h
-
-    $as_echo "#define HAVE_LOGL 1" >>confdefs.h
-
-    $as_echo "#define HAVE_MODFL 1" >>confdefs.h
-
-    $as_echo "#define HAVE_POWL 1" >>confdefs.h
-
-    $as_echo "#define HAVE_SINCOSL 1" >>confdefs.h
-
-    $as_echo "#define HAVE_SINL 1" >>confdefs.h
-
-    $as_echo "#define HAVE_SINHL 1" >>confdefs.h
-
-    $as_echo "#define HAVE_SQRTL 1" >>confdefs.h
-
-    $as_echo "#define HAVE_TANL 1" >>confdefs.h
-
-    $as_echo "#define HAVE_TANHL 1" >>confdefs.h
-
-  fi
 fi
 
 # Check for _Unwind_GetIPInfo.

--- a/libstdc++-v3/configure.ac
+++ b/libstdc++-v3/configure.ac
@@ -393,39 +393,55 @@ else
         AC_DEFINE(HAVE_USLEEP)
         ;;
     esac
+
+    # Newlib provides 80-bit long-double math on i386/x86_64.  Define
+    # the HAVE_*L macros so that the long-double stubs in
+    # src/c++98/math_stubs_long_double.cc are suppressed and do not
+    # conflict with newlib libm.a's strong definitions at static link
+    # time.
+    #
+    # Previously this set of AC_DEFINE calls lived in a block guarded by
+    #   if test x"long_double_math_on_this_cpu" = x"yes"; then ...
+    # which compares the literal string "long_double_math_on_this_cpu"
+    # against "yes" (the leading `$` was omitted) and is therefore
+    # permanently false.  The block carried a "for the time being, punt"
+    # comment since libstdc++'s introduction; promote it to a real CPU
+    # check now, scoped to newlib targets so non-newlib cross builds
+    # (which reach this file via GLIBCXX_CROSSCONFIG in the elif below)
+    # are unaffected.
+    case "${target_cpu}" in
+      i[[3456789]]86 | x86_64)
+        AC_DEFINE(HAVE_ACOSL)
+        AC_DEFINE(HAVE_ASINL)
+        AC_DEFINE(HAVE_ATAN2L)
+        AC_DEFINE(HAVE_ATANL)
+        AC_DEFINE(HAVE_CEILL)
+        AC_DEFINE(HAVE_COSL)
+        AC_DEFINE(HAVE_COSHL)
+        AC_DEFINE(HAVE_EXPL)
+        AC_DEFINE(HAVE_FABSL)
+        AC_DEFINE(HAVE_FLOORL)
+        AC_DEFINE(HAVE_FMODL)
+        AC_DEFINE(HAVE_FREXPL)
+        AC_DEFINE(HAVE_HYPOTL)
+        AC_DEFINE(HAVE_LDEXPL)
+        AC_DEFINE(HAVE_LOG10L)
+        AC_DEFINE(HAVE_LOGL)
+        AC_DEFINE(HAVE_MODFL)
+        AC_DEFINE(HAVE_POWL)
+        AC_DEFINE(HAVE_SINCOSL)
+        AC_DEFINE(HAVE_SINL)
+        AC_DEFINE(HAVE_SINHL)
+        AC_DEFINE(HAVE_SQRTL)
+        AC_DEFINE(HAVE_TANL)
+        AC_DEFINE(HAVE_TANHL)
+        ;;
+    esac
   elif test "x$with_headers" != "xno"; then
     GLIBCXX_CROSSCONFIG
   fi
-
-  # At some point, we should differentiate between architectures
-  # like x86, which have long double versions, and alpha/powerpc/etc.,
-  # which don't. For the time being, punt.
-  if test x"long_double_math_on_this_cpu" = x"yes"; then
-    AC_DEFINE(HAVE_ACOSL)
-    AC_DEFINE(HAVE_ASINL)
-    AC_DEFINE(HAVE_ATAN2L)
-    AC_DEFINE(HAVE_ATANL)
-    AC_DEFINE(HAVE_CEILL)
-    AC_DEFINE(HAVE_COSL)
-    AC_DEFINE(HAVE_COSHL)
-    AC_DEFINE(HAVE_EXPL)
-    AC_DEFINE(HAVE_FABSL)
-    AC_DEFINE(HAVE_FLOORL)
-    AC_DEFINE(HAVE_FMODL)
-    AC_DEFINE(HAVE_FREXPL)
-    AC_DEFINE(HAVE_LDEXPL)
-    AC_DEFINE(HAVE_LOG10L)
-    AC_DEFINE(HAVE_LOGL)
-    AC_DEFINE(HAVE_MODFL)
-    AC_DEFINE(HAVE_POWL)
-    AC_DEFINE(HAVE_SINCOSL)
-    AC_DEFINE(HAVE_SINL)
-    AC_DEFINE(HAVE_SINHL)
-    AC_DEFINE(HAVE_SQRTL)
-    AC_DEFINE(HAVE_TANL)
-    AC_DEFINE(HAVE_TANHL)
-  fi
 fi
+
 
 # Check for _Unwind_GetIPInfo.
 GCC_CHECK_UNWIND_GETIPINFO


### PR DESCRIPTION
## Summary

Fix a long-standing dead-code guard in `libstdc++-v3/configure.ac` that
prevented the `HAVE_*L` long-double math defines from being emitted on
i386/x86_64 newlib targets. On Nanvix this manifests as 24
multiple-definition link errors between `libstdc++.a`'s long-double
stubs and newlib `libm.a`'s real implementations when the C++ runtime
is whole-archived into an executable.

## Root cause

`libstdc++-v3/configure.ac`, in the "Construct crosses by hand" block:

```sh
# At some point, we should differentiate between architectures
# like x86, which have long double versions, and alpha/powerpc/etc.,
# which don't. For the time being, punt.
if test x"long_double_math_on_this_cpu" = x"yes"; then
    AC_DEFINE(HAVE_ACOSL)
    AC_DEFINE(HAVE_ASINL)
    ... # 23 HAVE_*L defines
fi
```

The shell expression `test x"long_double_math_on_this_cpu" = x"yes"`
compares the literal string `"long_double_math_on_this_cpu"` against
`"yes"` — there is no leading `$`, so no variable expansion occurs.
The condition is therefore **permanently false**, and the 23 `HAVE_*L`
`AC_DEFINE` calls below it have never executed in any configure run.

This bug is unchanged from official upstream
[`gcc-mirror/gcc`](https://github.com/gcc-mirror/gcc/blob/master/libstdc++-v3/configure.ac);
the same block is present and equally dead.

## Symptom on Nanvix

`libstdc++-v3/src/c++98/math_stubs_long_double.cc` ships fallback
long-double implementations for 24 functions (`acosl`, `asinl`, …,
`tanhl`, `hypotl`) each guarded by `#ifndef _GLIBCXX_HAVE_*L`. Because
the defines never fire, the fallbacks are always compiled into
`libstdc++.a` as **strong** ELF `T` symbols, e.g.:

```c++
extern "C" long double expl(long double x) { return exp((double) x); }
```

Nanvix's newlib provides the real 80-bit long-double math on i386 with
the same strong symbol names. Static-linking `libstdc++.a` together
with newlib `libm.a` — which Nanvix does for `python.elf` via
`-Wl,--whole-archive libstdc++.a libm.a` — fails with:

```
ld: libm.a(a-s_expl.o): multiple definition of `expl';
    libstdc++.a(math_stubs_long_double.o): first defined here
```

across all 24 long-double functions simultaneously.

This bug was masked for years because `libm.a(s_tanl.o)` had an
unresolved external `__kernel_tanl`, so `ld` silently skipped the
`s_tanl.o` member and let the libstdc++ stub win for `tanl`. Once
[`nanvix/newlib#10`](https://github.com/nanvix/newlib/pull/10) fixed
the `__kernel_tanl` reference, `s_tanl.o` started linking and the full
set of conflicts surfaced at once.

## Fix

Replace the always-false `if` with a real `case ${target_cpu}` block
that emits the 24 `HAVE_*L` defines for i386 and x86_64. The case
lives inside the `if test "x${with_newlib}" = "xyes"` branch of
`configure.ac`, so the change is scoped to newlib cross targets and
does not alter any other target's behavior:

```sh
if test "x${with_newlib}" = "xyes"; then
    ...
    case "${target}" in *-rtems*) ... esac

    case "${target_cpu}" in
      i[3456789]86 | x86_64)
        AC_DEFINE(HAVE_ACOSL)
        ...
        AC_DEFINE(HAVE_HYPOTL)
        ...
        AC_DEFINE(HAVE_TANHL)
        ;;
    esac
elif test "x$with_headers" != "xno"; then
    GLIBCXX_CROSSCONFIG
fi
```

`HAVE_HYPOTL` is added to the historic 23-function list because
newlib also provides a strong `hypotl` and the stub file ships a
`hypotl` guarded by `_GLIBCXX_HAVE_HYPOTL` (same conflict pattern).
`HAVE_SINCOSL` is kept for fidelity to the original dead block, even
though no code in libstdc++ references `_GLIBCXX_HAVE_SINCOSL`.

`libstdc++-v3/configure` is updated to include the equivalent generated shell. The shell idiom matches the surrounding generated code (compare with the `HAVE_*F` block immediately above).

## Why CPU-keyed inside the newlib branch

- Whether 80-bit long-double math is available is a property of the
  CPU/ABI, not the OS/libc. The dead block was already CPU-blind (it
  would have applied to every target if the literal-string bug were
  fixed); a CPU-keyed promotion is the smallest semantic change
  required to restore intent.
- Scoping to the `with_newlib` branch keeps the blast radius
  conservative: only newlib cross targets are affected by this PR.
  Non-newlib cross targets reach this file through the `elif` calling
  `GLIBCXX_CROSSCONFIG`, which is mutually exclusive with the `if`
  branch we modified.
- The historic comment above the dead block already anticipated this
  CPU distinction:
  > At some point, we should differentiate between architectures like
  > x86, which have long double versions, and alpha/powerpc/etc.,
  > which don't. For the time being, punt.

  This patch is the deferred follow-through.

## Why not patch `crossconfig.m4`'s `*-nanvix*` case instead

The `*-nanvix*` case in `crossconfig.m4` lives inside
`GLIBCXX_CROSSCONFIG`, which the newlib branch never invokes
(`configure.ac` line 340: `if test "x${with_newlib}" = "xyes"; then ...
elif test "x$with_headers" != "xno"; then GLIBCXX_CROSSCONFIG; fi`).
Defining the `HAVE_*L` macros inside `crossconfig.m4`'s `*-nanvix*`
case would therefore have no effect on the Nanvix toolchain build.

## Out of scope for this PR

`configure` contains two other instances of the same buggy `if test
x"long_double_math_on_this_cpu" = x"yes"` pattern inside
`crossconfig.m4` cases (Darwin and similar targets), each guarding
`HAVE_FINITEL`/`HAVE_ISINFL`/`HAVE_ISNANL`. Those are independent
defects affecting non-newlib targets and are left for a separate
upstream patch.

## Validation

End-to-end validated by:

- Rebuilding the Nanvix gcc 12.4 toolchain with this patch.
  `libstdc++.a` now has no strong `acosl`/`asinl`/…/`hypotl`/`tanhl`
  symbols:
  ```
  $ i686-nanvix-nm /opt/nanvix/i686-nanvix/lib/libstdc++.a \
      | grep -E ' T (acosl|asinl|expl|logl|sinl|cosl|tanl|powl|sqrtl|hypotl|fmodl)$' \
      | wc -l
  0
  ```
- Static-linking the full C++ runtime into Nanvix's `python.elf` with
  `-Wl,--whole-archive libstdc++.a libm.a -Wl,--no-whole-archive`
  succeeds cleanly (previously failed with 24 multiple-definition
  errors).
- numpy 1.26.4 cross-compiles to `.so` modules against this toolchain
  and imports successfully on a Nanvix microvm: `import numpy`,
  `numpy.__version__ == '1.26.4'`, `arange`/`sum`/`dot`/`reshape` all
  work via `dlopen()` of true dynamic shared objects.

`bits/c++config.h` after the patch contains the expected defines:

```
#define _GLIBCXX_HAVE_ACOSL 1
#define _GLIBCXX_HAVE_ASINL 1
...
#define _GLIBCXX_HAVE_HYPOTL 1
...
#define _GLIBCXX_HAVE_TANHL 1
```

## Files changed

- `libstdc++-v3/configure.ac` — replace the always-false `if test
  x"long_double_math_on_this_cpu"` block with a `case
  "${target_cpu}"` inside the `--with-newlib` branch; add
  `HAVE_HYPOTL`.
- `libstdc++-v3/configure` — corresponding generated shell.

## Related

- nanvix/newlib#10 — back-ports `k_tanl.c` and exposed this libstdc++
  bug.
- This is also a bug in official upstream gcc; re-submission to
  `gcc-patches@gcc.gnu.org` is planned as a follow-up once matrix
  validation against another newlib x86 cross (e.g. i386-elf) is in
  hand.

