### PR TITLE
libstdc++: skip POSIX-feature detection for *-nanvix*

### DIFF
--- a/libstdc++-v3/configure
+++ b/libstdc++-v3/configure
@@ -29330,8 +29330,31 @@ else
 
     $as_echo "#define HAVE_ICONV 1" >>confdefs.h
 
-    $as_echo "#define HAVE_MEMALIGN 1" >>confdefs.h
 
+    case "${target}" in
+      *-nanvix*)
+        ;;
+      *)
+        $as_echo "#define HAVE_MEMALIGN 1" >>confdefs.h
+
+        ;;
+    esac
+
+    # On nanvix, newlib's headers declare a number of POSIX functions
+    # whose implementations are not provided by the sysroot.  Pre-seed
+    # the AC_CACHE_CHECK cache variables to "no" so the link tests are
+    # skipped and the matching HAVE_* macros stay undefined.
+    case "${target}" in
+      *-nanvix*)
+        glibcxx_cv_fchmodat=no
+        glibcxx_cv_unlinkat=no
+        glibcxx_cv_dirfd=no
+        glibcxx_cv_openat=no
+        glibcxx_cv_fdopendir=no
+        ac_cv_func_posix_memalign=no
+        ac_cv_header_sys_statvfs_h=no
+        ;;
+    esac
 
     case "${target}" in
       *-rtems*)

--- a/libstdc++-v3/configure.ac
+++ b/libstdc++-v3/configure.ac
@@ -368,7 +368,38 @@ else
     AC_DEFINE(HAVE_TANHF)
 
     AC_DEFINE(HAVE_ICONV)
-    AC_DEFINE(HAVE_MEMALIGN)
+
+    case "${target}" in
+      *-nanvix*)
+        ;;
+      *)
+        AC_DEFINE(HAVE_MEMALIGN)
+        ;;
+    esac
+
+    # On nanvix, newlib's headers declare a number of POSIX functions
+    # whose implementations are not provided by the sysroot.  The
+    # autoconf link-tests in GLIBCXX_CHECK_FILESYSTEM_DEPS (acinclude.m4)
+    # and AC_CHECK_FUNCS(posix_memalign) (configure.ac) then succeed
+    # and AC_DEFINE the corresponding HAVE_* macros, leaving libstdc++
+    # objects with undefined references that the loader cannot
+    # resolve.  Pre-seed the AC_CACHE_CHECK cache variables to "no"
+    # for *-nanvix* so the checks are skipped and the matching
+    # HAVE_* macros stay undefined.  Required entries cover symbols
+    # observed in libstdc++.a's undefined list (fchmodat, unlinkat,
+    # dirfd, posix_memalign); the remaining entries are defensive
+    # against future newlib header changes.
+    case "${target}" in
+      *-nanvix*)
+        glibcxx_cv_fchmodat=no
+        glibcxx_cv_unlinkat=no
+        glibcxx_cv_dirfd=no
+        glibcxx_cv_openat=no
+        glibcxx_cv_fdopendir=no
+        ac_cv_func_posix_memalign=no
+        ac_cv_header_sys_statvfs_h=no
+        ;;
+    esac
 
     case "${target}" in
       *-rtems*)


### PR DESCRIPTION
## Summary

Forces libstdc++ to skip a handful of POSIX-feature detection probes when configured for `*-nanvix*`. Without these overrides libstdc++.a is built with undefined references to POSIX functions (`posix_memalign`, `fchmodat`, `dirfd`, `unlinkat`, ...) that newlib declares but does not implement. Those undefined references then break `dlopen()`-based loading of C++-using shared objects (such as numpy's `_multiarray_umath.so`) on the nanvix loader.

Stacked on top of #56 (PR-6a: long-double math defines). Merge #56 first.

## Changes

* Add a `*-nanvix*` case before `AC_DEFINE(HAVE_MEMALIGN)` (in the `with_newlib` branch). For nanvix the macro is left undefined and `libsupc++/new_opa.cc` falls back to its malloc-based aligned-allocation path (lines 100-116), which only needs `malloc`/`free`.
* Pre-seed `AC_CACHE_CHECK` cache variables to `no` for nanvix:
  * `glibcxx_cv_fchmodat=no`
  * `glibcxx_cv_unlinkat=no`
  * `glibcxx_cv_dirfd=no`
  * `glibcxx_cv_openat=no`
  * `glibcxx_cv_fdopendir=no`
  * `ac_cv_func_posix_memalign=no`
  * `ac_cv_header_sys_statvfs_h=no`

  The first three correspond to symbols actually observed as undefined in libstdc++.a's UND list (in `cow-fs_dir.o`, `cow-fs_ops.o`, `fs_dir.o`, `fs_ops.o`, `new_opa.o`). The remaining four are defensive against future newlib header changes that could re-enable these probes.

The pattern mirrors the existing `*-rtems*` handling in the same `with_newlib` branch (`configure.ac:373`).

The generated file `libstdc++-v3/configure` was hand-edited to mirror the `.ac` changes; running `autoconf` on this tree produces the same result.

## Verification

* Before, on a Phase A `libstdc++.a` built without these overrides: `nm -u libstdc++.a` listed `posix_memalign` (new_opa.o), `fchmodat` (cow-fs_ops.o, fs_ops.o), `dirfd`, `unlinkat` (cow-fs_dir.o, fs_dir.o).
* After, on the rebuilt `libstdc++.a`: `nm -u libstdc++.a | grep -E ' U (fchmodat|unlinkat|dirfd|posix_memalign|memalign|openat|fdopendir|statvfs)\$'` is empty.
* cpython (with libstdc++ statically embedded via `--whole-archive`) links cleanly and `python.elf` runs on the nanvix microvm.
* numpy 1.26.4 imports and runs correctly via `dlopen()` against the newly-clean libstdc++ (`NUMPY_TEST_OK` end-to-end).

## Related

* Part of the .so-enablement upstream chain for numpy on nanvix.
* Stacked on PR #56 (PR-6a: long-double math defines).

